### PR TITLE
Adds condition to ensure that a file save message in the echo area is not cleared when saving a file

### DIFF
--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -145,7 +145,7 @@ message to display, so there is one ;)"
   "Returns t if Flymake Cursor is safe to display to the minibuffer or nil if
 something else is using the message area."
   ;;  Don't trash the minibuffer while they're being asked a question.
-  (not (or (active-minibuffer-window) cursor-in-echo-area)))
+  (not (or (active-minibuffer-window) (current-message) cursor-in-echo-area)))
 
 (defun flymake-cursor-show-stored-errors-now ()
   "Displays the stored error in the minibuffer."


### PR DESCRIPTION
When flymake-cursor is activated, the message of what file was saved with C-x C-s blips on the echo area. The required behaviour is that it stays until another key is touched.
