### PR TITLE
remove annoying template from error messages

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,12 +1,14 @@
 flymake-cursor.el
 =================
 
-NOTE: This project is no longer actively maintained, please consider https://github.com/flycheck/flycheck instead.
+This is a fork of https://github.com/flymake/emacs-flymake-cursor
+which is fork of https://www.emacswiki.org/emacs/flymake-cursor.el.
 
-This project is a plugin for Emacs to work in conjunction with flymake.el
-it displays any flymake error for the current line on the minibuffer.
+It also works with latest flymake (Emacs >= 26) unlike upstream
 
-The project is a fork of http://www.emacswiki.org/emacs/flymake-cursor.el
+This project is a plugin for Emacs to work in conjunction with
+flymake.el it displays any flymake error for the current line on the
+minibuffer.
 
 It adds the following features:
 
@@ -20,14 +22,17 @@ It adds the following features:
 
 INSTALLATION
 ------------
+Clone repo
 
-####Package Manager
-This package is available on [MELPA](https://melpa.org) and [MELPA Stable](https://stable.melpa.org), so you can 
-```
-M-x package-install flymake-cursor
+#### use-package
+```lisp
+(use-package flymake-cursor
+  :load-path "~/.emacs.d/lisp/emacs-flymake-cursor" ;; cloned repo path
+  :config
+  (flymake-cursor-mode))
 ```
 
-####Self installation
+#### manual
 Place `flymake-cursor.el` within your Emacs `load-path` and the following to your
 `.emacs` file or your `init.el`:
 

--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -143,7 +143,7 @@ the mode directly."
   "pyflake is flakey if it has compile problems, this adjusts the
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
-        ((boundp 'flymake-diagnostic-text)
+        ((fboundp 'flymake-diagnostic-text)
          (let ((msg (flymake-diagnostic-text error)))
            (if (null msg) msg (format "compile error, problem on line %s" msg))))
         (t

--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -126,20 +126,29 @@ the mode directly."
 
 (defun flymake-cursor-get-errors-at-point ()
   "Gets the first `flymake-cursor-number-of-errors-to-display` flymake errors on the line at point."
-  (let ((line-err-info-list (nth 0 (flymake-find-err-info flymake-err-info (line-number-at-pos)))))
+  (let ((line-err-info-list (flymake-cursor-get-errors)))
     (if flymake-cursor-number-of-errors-to-display
-      (butlast line-err-info-list (- (length line-err-info-list) flymake-cursor-number-of-errors-to-display))
+        (butlast line-err-info-list (- (length line-err-info-list) flymake-cursor-number-of-errors-to-display))
       line-err-info-list)))
+
+(defun flymake-cursor-get-errors ()
+  (cond ((boundp 'flymake-err-info)  ; emacs < 26
+         (let ((lineno (line-number-at-pos)))
+           (err-info (car (flymake-find-err-info flymake-err-info lineno)))))
+        ((and (fboundp 'flymake-diagnostic-text)
+              (fboundp 'flymake-diagnostics))  ; emacs >= 26
+         (flymake-diagnostics (point)))))
 
 (defun flymake-cursor-pyflake-determine-message (error)
   "pyflake is flakey if it has compile problems, this adjusts the
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
-        ((null (flymake-ler-file error))
-         ;; normal message do your thing
-         (flymake-ler-text error))
-        (t ;; could not compile error
-         (format "compile error, problem on line %s" (flymake-ler-line error)))))
+        ((boundp 'flymake-ler-file)
+         (let ((msg (flymake-ler-file error)))
+           (if (null msg) msg (format "compile error, problem on line %s" msg))))
+        (t
+         (let ((msg (flymake-diagnostic-text error)))
+           (if (null msg) msg (format "compile error, problem on line %s" msg))))))
 
 (defun flymake-cursor-safe-to-display ()
   "Returns t if Flymake Cursor is safe to display to the minibuffer or nil if

--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -144,8 +144,7 @@ the mode directly."
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
         ((fboundp 'flymake-diagnostic-text)
-         (let ((msg (flymake-diagnostic-text error)))
-           (if (null msg) msg (format "compile error, problem on line %s" msg))))
+         (let ((msg (flymake-diagnostic-text error))) msg))
         (t
          (flymake-ler-text error))))
 

--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -134,7 +134,7 @@ the mode directly."
 (defun flymake-cursor-get-errors ()
   (cond ((boundp 'flymake-err-info)  ; emacs < 26
          (let ((lineno (line-number-at-pos)))
-           (err-info (car (flymake-find-err-info flymake-err-info lineno)))))
+           (car (flymake-find-err-info flymake-err-info lineno))))
         ((and (fboundp 'flymake-diagnostic-text)
               (fboundp 'flymake-diagnostics))  ; emacs >= 26
          (flymake-diagnostics (point)))))
@@ -143,12 +143,11 @@ the mode directly."
   "pyflake is flakey if it has compile problems, this adjusts the
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
-        ((boundp 'flymake-ler-file)
-         (let ((msg (flymake-ler-file error)))
+        ((boundp 'flymake-diagnostic-text)
+         (let ((msg (flymake-diagnostic-text error)))
            (if (null msg) msg (format "compile error, problem on line %s" msg))))
         (t
-         (let ((msg (flymake-diagnostic-text error)))
-           (if (null msg) msg (format "compile error, problem on line %s" msg))))))
+         (flymake-ler-text error))))
 
 (defun flymake-cursor-safe-to-display ()
   "Returns t if Flymake Cursor is safe to display to the minibuffer or nil if


### PR DESCRIPTION
Remove annoying and redundant "compile error, problem on line %s" from each error message.

%s didn't work anyway.